### PR TITLE
Add LF reviewed communications policy to Foundation

### DIFF
--- a/COMMUNICATION-POLICY.md
+++ b/COMMUNICATION-POLICY.md
@@ -1,0 +1,26 @@
+# Presto Community Channels Communications Policy
+
+## Our Pledge 
+In the interest of fostering an open and welcoming environment, the Presto Foundation is committed to making participation in our project one free from distraction, confusion, and solicitation. 
+
+## Community Channels
+As your participation in our project happens in various settings, this policy covers all interactions with community members in Presto Foundation related online and off-line settings. This can include but is not limited to, the Presto Foundation meetup groups, PrestoCon events, comments sections on Presto related forums, Presto Foundation Slack channel and direct messaging services, mailing lists, and any other community events which include Presto discussions.  
+
+## Communication Policy
+
+- Be helpful and welcoming: Try to understand the problem with empathy. Welcome others to the community and be helpful, even if they are associated with competing organizations. If you do not have something helpful to say, it’s fine to keep your thoughts to yourself.
+
+- Stay on topic: Community interactions amongst participants need to be focused on the topic up for discussion in a thread.
+
+- Don’t use profanity: Participants need to use welcoming and inclusive language, profane language must not be used. 
+
+- Non-solicitation: Participants must not use the Community Channels to solicit people to a company’s channels or drive people to an alternative open source project. However, if a participant is directly asking about another project, it is prudent to let them know they're in the wrong community channel.
+
+- Don’t confuse: Participants need to use accurate information to the best of each one’s abilities. Participants must not interact with each other in a way that confuses the brand represented by the Presto trademark.
+
+- Adhere to the Code of Conduct: this policy is in addition to the Code of Conduct. 
+
+## Transgression
+Instances of participants violating this policy may be reported to the TSC Chair or Outreach Committee Chair. If these community options would create a concern for you, please follow the Linux Foundation’s event Code of Conduct at https://events.linuxfoundation.org/about/code-of-conduct. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. 
+
+Participants who do not follow or enforce the Communication Policy will be warned up to two times. Any comment captured on a system in violation of this policy will be subject to deletion. The third transgression will result in a 3-month ban from the community. If there is a fourth transgression, the participant can expect a permanent ban from the community.


### PR DESCRIPTION
Linux Foundation has reviewed and approved the Communications Policy for the community channels for Presto Foundation. This PR adds the policy.